### PR TITLE
Python 2/3 polyglotting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals, division
+
 """Setup
 """
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, print_function, unicode_literals, division
+from __future__ import absolute_import, print_function, division
 
 """Setup
 """
@@ -13,7 +13,7 @@ except:
 
 def read(*rnames):
     text = open(os.path.join(os.path.dirname(__file__), *rnames)).read()
-    return unicode(text, 'utf-8').encode('ascii', 'xmlcharrefreplace')
+    return text
 
 
 setup(
@@ -50,7 +50,6 @@ setup(
             'mock'
         ),
         zope=(
-            'rwproperty',
             'zope.container',
         ),
     ),

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,11 @@ import os
 from setuptools import setup, find_packages
 
 
+try:
+    unicode
+except:
+    unicode = str
+
 def read(*rnames):
     text = open(os.path.join(os.path.dirname(__file__), *rnames)).read()
     return unicode(text, 'utf-8').encode('ascii', 'xmlcharrefreplace')

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 
 """Setup
 """

--- a/src/pjpersist/datamanager.py
+++ b/src/pjpersist/datamanager.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """PostGreSQL/JSONB Persistent Data Manager"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import UserDict
 import binascii
 import hashlib

--- a/src/pjpersist/datamanager.py
+++ b/src/pjpersist/datamanager.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """PostGreSQL/JSONB Persistent Data Manager"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import UserDict
 import binascii
 import hashlib

--- a/src/pjpersist/interfaces.py
+++ b/src/pjpersist/interfaces.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """PG/JSONB Persistence Interfaces"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import datetime
 import decimal
 import persistent.interfaces

--- a/src/pjpersist/interfaces.py
+++ b/src/pjpersist/interfaces.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """PG/JSONB Persistence Interfaces"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import datetime
 import decimal
 import persistent.interfaces

--- a/src/pjpersist/interfaces.py
+++ b/src/pjpersist/interfaces.py
@@ -23,7 +23,13 @@ import types
 import zope.interface
 import zope.schema
 
-PJ_NATIVE_TYPES = (bool, float, type(None)) + six.integer_types + six.string_types
+PJ_NATIVE_TYPES = (bool, float, type(None)) + six.integer_types + (str,)
+
+if six.PY2:
+    PJ_NATIVE_TYPES += (unicode,)
+else:
+    PJ_NATIVE_TYPES += (bytes,)
+
 REFERENCE_SAFE_TYPES = (
     datetime.datetime, datetime.date, datetime.time, decimal.Decimal)
 

--- a/src/pjpersist/interfaces.py
+++ b/src/pjpersist/interfaces.py
@@ -17,13 +17,13 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 import datetime
 import decimal
 import persistent.interfaces
+import six
 import transaction.interfaces
 import types
 import zope.interface
 import zope.schema
 
-PJ_NATIVE_TYPES = (
-    bool, int, long, float, unicode, types.NoneType)
+PJ_NATIVE_TYPES = (bool, float, type(None)) + six.integer_types + six.text_types
 REFERENCE_SAFE_TYPES = (
     datetime.datetime, datetime.date, datetime.time, decimal.Decimal)
 
@@ -204,10 +204,10 @@ class IColumnSerialization(zope.interface.Interface):
     """
 
     _pj_column_fields = zope.schema.Tuple(
-        title=u'Column Fields',
-        description=(u'A list of zope.schema fields that represent columns '
-                     u'in the storage table. Fields cannot be named `id` or '
-                     u'`data` as those attributes are reserved.'),
+        title='Column Fields',
+        description=('A list of zope.schema fields that represent columns '
+                     'in the storage table. Fields cannot be named `id` or '
+                     '`data` as those attributes are reserved.'),
         required=True)
 
     def _pj_get_column_fields():

--- a/src/pjpersist/interfaces.py
+++ b/src/pjpersist/interfaces.py
@@ -23,7 +23,7 @@ import types
 import zope.interface
 import zope.schema
 
-PJ_NATIVE_TYPES = (bool, float, type(None)) + six.integer_types + six.text_types
+PJ_NATIVE_TYPES = (bool, float, type(None)) + six.integer_types + six.string_types
 REFERENCE_SAFE_TYPES = (
     datetime.datetime, datetime.date, datetime.time, decimal.Decimal)
 

--- a/src/pjpersist/mapping.py
+++ b/src/pjpersist/mapping.py
@@ -14,11 +14,11 @@
 ##############################################################################
 """PostGreSQL/JSONB Mapping Implementations"""
 from __future__ import absolute_import, print_function, unicode_literals, division
-import UserDict
 
+from collections import Mapping
 from pjpersist import serialize
 
-class PJTableMapping(UserDict.DictMixin, object):
+class PJTableMapping(Mapping, object):
     __pj_table__ = None
     __pj_mapping_key__ = 'key'
 

--- a/src/pjpersist/mapping.py
+++ b/src/pjpersist/mapping.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """PostGreSQL/JSONB Mapping Implementations"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import UserDict
 
 from pjpersist import serialize

--- a/src/pjpersist/mapping.py
+++ b/src/pjpersist/mapping.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """PostGreSQL/JSONB Mapping Implementations"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import UserDict
 
 from pjpersist import serialize

--- a/src/pjpersist/persistent.py
+++ b/src/pjpersist/persistent.py
@@ -19,9 +19,8 @@ import zope.interface
 from pjpersist import interfaces
 
 
+@zope.interface.implementer(interfaces.IPersistentSerializationHooks)
 class PersistentSerializationHooks(persistent.Persistent):
-    zope.interface.implements(interfaces.IPersistentSerializationHooks)
-
     def _pj_after_store_hook(self, conn):
         return None
 
@@ -29,9 +28,8 @@ class PersistentSerializationHooks(persistent.Persistent):
         return None
 
 
+@zope.interface.implementer(interfaces.IColumnSerialization)
 class SimpleColumnSerialization(object):
-    zope.interface.implements(interfaces.IColumnSerialization)
-
     _pj_column_fields = ()
 
     def _pj_get_column_fields(self):

--- a/src/pjpersist/persistent.py
+++ b/src/pjpersist/persistent.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """Persistent Object Support"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import persistent
 import zope.interface
 

--- a/src/pjpersist/persistent.py
+++ b/src/pjpersist/persistent.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """Persistent Object Support"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import persistent
 import zope.interface
 

--- a/src/pjpersist/pool.py
+++ b/src/pjpersist/pool.py
@@ -27,9 +27,8 @@ LOCAL = threading.local()
 # XXX: THIS SEEMS MAJORLY BROKEN< SINCE CONNECTIONS ARE NEVER RETURNED TO THE
 # POOL.
 
+@zope.interface.implementer(interfaces.IPJDataManagerProvider)
 class PJDataManagerProvider(object):
-    zope.interface.implements(interfaces.IPJDataManagerProvider)
-
     def __init__(self, user=None, password=None, host='localhost', port=5432,
                  pool_min_conn=1, pool_max_conn=8):
         self.user = user

--- a/src/pjpersist/pool.py
+++ b/src/pjpersist/pool.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """Thread-aware PG/JSONB Connection Pool"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
 import threading
 import psycopg2

--- a/src/pjpersist/pool.py
+++ b/src/pjpersist/pool.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """Thread-aware PG/JSONB Connection Pool"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import logging
 import threading
 import psycopg2

--- a/src/pjpersist/querystats.py
+++ b/src/pjpersist/querystats.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """Statistics on executed queries"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 
 import sys
 from collections import namedtuple

--- a/src/pjpersist/querystats.py
+++ b/src/pjpersist/querystats.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """Statistics on executed queries"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 
 import sys
 from collections import namedtuple

--- a/src/pjpersist/serialize.py
+++ b/src/pjpersist/serialize.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """Object Serialization for PostGreSQL's JSONB"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import copy
 import copy_reg
 import datetime

--- a/src/pjpersist/serialize.py
+++ b/src/pjpersist/serialize.py
@@ -15,7 +15,8 @@
 """Object Serialization for PostGreSQL's JSONB"""
 from __future__ import absolute_import, print_function, unicode_literals, division
 import copy
-import copy_reg
+from six.moves import copyreg
+import six
 import datetime
 
 import persistent.interfaces
@@ -38,12 +39,9 @@ TABLE_KLASS_MAP = {}
 
 # actually we should extract this somehow from psycopg2
 PYTHON_TO_PG_TYPES = {
-    unicode: "text",
     str: "text",
     bool: "bool",
     float: "double",
-    int: "integer",
-    long: "bigint",
     #Decimal: "number",
     datetime.date: "date",
     datetime.time: "time",
@@ -51,6 +49,19 @@ PYTHON_TO_PG_TYPES = {
     datetime.timedelta: "interval",
     list: "array",
 }
+
+
+if six.PY3:
+    PYTHON_TO_PG_TYPES.update({
+        int: "bigint"
+    })
+
+else:
+    PYTHON_TO_PG_TYPES.update({
+        int: "bigint",
+        long: "bigint",
+        unicode: "text"
+    })
 
 
 def get_dotted_name(obj, escape=False):
@@ -170,7 +181,7 @@ class ObjectWriter(object):
                 getattr(obj, '_pj_reference_safe', False)):
             seen.append(id(obj))
         # Get the state of the object. Only pickable objects can be reduced.
-        reduce_fn = copy_reg.dispatch_table.get(type(obj))
+        reduce_fn = copyreg.dispatch_table.get(type(obj))
         if reduce_fn is not None:
             reduced = reduce_fn(obj)
         else:
@@ -191,12 +202,12 @@ class ObjectWriter(object):
                 obj_state = {}
         # We are trying very hard to create a clean JSONB (sub-)document. But
         # we need a little bit of meta-data to help us out later.
-        if factory == copy_reg._reconstructor and \
+        if factory == copyreg._reconstructor and \
                args == (obj.__class__, object, None):
             # This is the simple case, which means we can produce a nicer
             # JSONB output.
             state = {'_py_type': get_dotted_name(args[0])}
-        elif factory == copy_reg.__newobj__ and args == (obj.__class__,):
+        elif factory == copyreg.__newobj__ and args == (obj.__class__,):
             # Another simple case for persistent objects that do not want
             # their own document.
             state = {interfaces.PY_TYPE_ATTR_NAME: get_dotted_name(args[0])}
@@ -246,7 +257,7 @@ class ObjectWriter(object):
             if serializer.can_write(obj):
                 return serializer.write(obj)
 
-        if isinstance(obj, (type, types.ClassType)):
+        if isinstance(obj, six.class_types):
             # We frequently store class and function paths as meta-data, so we
             # need to be able to properly encode those.
             return {'_py_type': 'type',
@@ -274,8 +285,8 @@ class ObjectWriter(object):
             data = []
             for key, value in obj.items():
                 data.append((key, self.get_state(value, pobj, seen)))
-                has_non_string_key |= not isinstance(key, basestring)
-                if (not isinstance(key, basestring) or '\0' in key):
+                has_non_string_key |= not isinstance(key, six.string_types)
+                if (not isinstance(key, six.string_types) or '\0' in key):
                     has_non_string_key = True
             if not has_non_string_key:
                 # The easy case: all keys are strings:
@@ -445,12 +456,12 @@ class ObjectReader(object):
         if '_py_type' in state:
             # Handle the simplified case.
             klass = self.simple_resolve(state.pop('_py_type'))
-            sub_obj = copy_reg._reconstructor(klass, object, None)
+            sub_obj = copyreg._reconstructor(klass, object, None)
         elif interfaces.PY_TYPE_ATTR_NAME in state:
             # Another simple case for persistent objects that do not want
             # their own document.
             klass = self.simple_resolve(state.pop(interfaces.PY_TYPE_ATTR_NAME))
-            sub_obj = copy_reg.__newobj__(klass)
+            sub_obj = copyreg.__newobj__(klass)
         else:
             factory = self.simple_resolve(state.pop('_py_factory'))
             factory_args = self.get_object(state.pop('_py_factory_args'), obj)
@@ -515,7 +526,7 @@ class ObjectReader(object):
             if 'dict_data' in state:
                 items = state['dict_data']
             else:
-                items = state.items()
+                items = list(state.items())
             sub_obj = dict(
                 [(self.get_object(name, obj), self.get_object(value, obj))
                  for name, value in items])

--- a/src/pjpersist/serialize.py
+++ b/src/pjpersist/serialize.py
@@ -13,7 +13,7 @@
 #
 ##############################################################################
 """Object Serialization for PostGreSQL's JSONB"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import copy
 import copy_reg
 import datetime

--- a/src/pjpersist/testing.py
+++ b/src/pjpersist/testing.py
@@ -25,7 +25,7 @@ import threading
 import transaction
 import unittest
 from pprint import pprint
-from StringIO import StringIO
+from io import StringIO
 
 import zope.component
 from zope.testing import module, renormalizing
@@ -141,7 +141,7 @@ def setUp(test):
         with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
             try:
                 cur.execute('SELECT * FROM ' + table)
-            except psycopg2.ProgrammingError, err:
+            except psycopg2.ProgrammingError as err:
                 print(err)
             else:
                 pprint([dict(e) for e in cur.fetchall()])

--- a/src/pjpersist/testing.py
+++ b/src/pjpersist/testing.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """Mongo Persistence Testing Support"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import atexit
 import doctest
 import logging

--- a/src/pjpersist/testing.py
+++ b/src/pjpersist/testing.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """Mongo Persistence Testing Support"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import atexit
 import doctest
 import logging
@@ -142,7 +142,7 @@ def setUp(test):
             try:
                 cur.execute('SELECT * FROM ' + table)
             except psycopg2.ProgrammingError, err:
-                print err
+                print(err)
             else:
                 pprint([dict(e) for e in cur.fetchall()])
         if isolate:

--- a/src/pjpersist/tests/json_speed_test.py
+++ b/src/pjpersist/tests/json_speed_test.py
@@ -18,8 +18,8 @@ DATA_ORIG = {
         Vestibulum augue augue,
         pellentesque quis sollicitudin id, adipiscing.
         """,
-    'list': range(100),
-    'dict': dict((str(i), 'a') for i in xrange(100)),
+    'list': list(range(100)),
+    'dict': dict((str(i), 'a') for i in range(100)),
     'int': 100,
     'float': 100.123456
 }

--- a/src/pjpersist/tests/json_speed_test.py
+++ b/src/pjpersist/tests/json_speed_test.py
@@ -57,17 +57,17 @@ def main():
     enc_table = []
     dec_table = []
 
-    print "Running tests (%d LOOPS each)" % LOOPS
-    print "Data repr length: %d" % len(setup)
+    print("Running tests (%d LOOPS each)" % LOOPS)
+    print("Data repr length: %d" % len(setup))
 
     for title, mod, enc, dec in tests:
-        print title
+        print(title)
 
-        print "  [Encode]", enc
+        print("  [Encode]", enc)
         result = timeit(enc, mod, number=LOOPS)
         enc_table.append([title, result])
 
-        print "  [Decode]", dec
+        print("  [Decode]", dec)
         result = timeit(dec, mod, number=LOOPS)
         dec_table.append([title, result])
 
@@ -83,11 +83,11 @@ def main():
     for x in dec_table:
         x[0] = x[0].ljust(20)
 
-    print "\nData repr length: %d" % len(setup)
-    print "\nEncoding Test (%d LOOPS)" % LOOPS
+    print("\nData repr length: %d" % len(setup))
+    print("\nEncoding Test (%d LOOPS)" % LOOPS)
     pprint.pprint(enc_table)
 
-    print "\nDecoding Test (%d LOOPS)" % LOOPS
+    print("\nDecoding Test (%d LOOPS)" % LOOPS)
     pprint.pprint(dec_table)
 
 

--- a/src/pjpersist/tests/performance.py
+++ b/src/pjpersist/tests/performance.py
@@ -23,7 +23,8 @@ import sys
 import tempfile
 import time
 import transaction
-import cPickle
+from six.moves import pickle
+from six import xrange
 import cProfile
 
 from pjpersist import datamanager
@@ -161,7 +162,7 @@ class PerformanceBase(object):
                 '[person.name for person in people.values()]', globals(), locals(),
                 filename=self.profile_output+'_fast_read_values')
         else:
-            [person.name for person in people.values()]
+            [person.name for person in list(people.values())]
         t2 = time.time()
         transaction.commit()
         self.printResult('Fast Read (values)', t1, t2, peopleCnt)
@@ -184,9 +185,9 @@ class PerformanceBase(object):
         # Profile object caching
         transaction.begin()
         # cache warmup
-        [person.name for person in people.values()]
+        [person.name for person in list(people.values())]
         t1 = time.time()
-        [person.name for person in people.values()]
+        [person.name for person in list(people.values())]
         #cProfile.runctx(
         #    '[person.name for person in people.values()]', globals(), locals())
         t2 = time.time()
@@ -195,10 +196,10 @@ class PerformanceBase(object):
 
         transaction.begin()
         # cache warmup
-        [person.name for person in people.values()]
+        [person.name for person in list(people.values())]
         t1 = time.time()
-        [person.name for person in people.values()]
-        [person.name for person in people.values()]
+        [person.name for person in list(people.values())]
+        [person.name for person in list(people.values())]
         #cProfile.runctx(
         #    '[person.name for person in people.values()]', globals(), locals())
         t2 = time.time()
@@ -225,7 +226,7 @@ class PerformanceBase(object):
     def delete(self, people, peopleCnt):
         # Profile deletion
         t1 = time.time()
-        for name in people.keys():
+        for name in list(people.keys()):
             if PROFILE:
                 cProfile.runctx(
                     'del people[name]', globals(), locals(),

--- a/src/pjpersist/tests/performance.py
+++ b/src/pjpersist/tests/performance.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """PJ Persistence Performance Test"""
-from __future__ import absolute_import, unicode_literals, division
+from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
 import optparse
 import os
@@ -100,7 +100,7 @@ class PerformanceBase(object):
         if count:
             ops = "%d ops/second" % (count / dur)
 
-        print '%-25s %.4f secs %s' % (text, dur, ops)
+        print('%-25s %.4f secs %s' % (text, dur, ops))
 
         PJLOGGER.debug('=========== done: %s', text)
 
@@ -474,7 +474,7 @@ def main(args=None):
 
     testing.setUpSerializers(None)
 
-    print 'PJ ---------------'
+    print('PJ ---------------')
     PerformancePJ().run_basic_crud(options)
-    print 'ZODB  ---------------'
+    print('ZODB  ---------------')
     PerformanceZODB().run_basic_crud(options)

--- a/src/pjpersist/tests/performance.py
+++ b/src/pjpersist/tests/performance.py
@@ -99,7 +99,7 @@ class PerformanceBase(object):
         text += ':'
         ops = ''
         if count:
-            ops = "%d ops/second" % (count / dur)
+            ops = "%f ops/second" % (count / dur)
 
         print('%-25s %.4f secs %s' % (text, dur, ops))
 

--- a/src/pjpersist/tests/performance.py
+++ b/src/pjpersist/tests/performance.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 """PJ Persistence Performance Test"""
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals, division
 import logging
 import optparse
 import os

--- a/src/pjpersist/tests/random_data_generator.py
+++ b/src/pjpersist/tests/random_data_generator.py
@@ -1,7 +1,7 @@
 import datetime
 import pprint
 import random
-
+from six import xrange
 
 DTIMES = [
     datetime.datetime(2013,1,22,18,59),

--- a/src/pjpersist/tests/test_mquery.py
+++ b/src/pjpersist/tests/test_mquery.py
@@ -17,7 +17,7 @@ from pjpersist import testing, mquery
 
 
 def run(sqlx):
-    print sqlx.__sqlrepr__('postgres')
+    print(sqlx.__sqlrepr__('postgres'))
 
 
 def test_convert():

--- a/src/pjpersist/tests/test_mquery_db.py
+++ b/src/pjpersist/tests/test_mquery_db.py
@@ -50,10 +50,10 @@ def select(conn, query, print_sql=False):
                 'postgres'
             )
             if print_sql:
-                print 'SQL> ', sql
+                print('SQL> ', sql)
             cur.execute(sql)
             for e in cur.fetchall():
-                print e[0]
+                print(e[0])
     finally:
         conn.rollback()
 

--- a/src/pjpersist/tests/test_serialize.py
+++ b/src/pjpersist/tests/test_serialize.py
@@ -16,7 +16,7 @@ import datetime
 import doctest
 import persistent
 import pprint
-import copy_reg
+from six.moves import copyreg
 
 from pjpersist import interfaces, serialize, testing
 
@@ -61,7 +61,7 @@ Constant = Constant()
 class CopyReggedConstant(object):
     def custom_reduce_fn(self):
         return 'CopyReggedConstant'
-copy_reg.pickle(CopyReggedConstant, CopyReggedConstant.custom_reduce_fn)
+copyreg.pickle(CopyReggedConstant, CopyReggedConstant.custom_reduce_fn)
 CopyReggedConstant = CopyReggedConstant()
 
 

--- a/src/pjpersist/tests/test_serialize_db.py
+++ b/src/pjpersist/tests/test_serialize_db.py
@@ -75,7 +75,7 @@ def select(conn, query, print_sql=False, **kwargs):
                 'postgres'
             )
             if print_sql:
-                print 'SQL> ', sql
+                print('SQL> ', sql)
             cur.execute(sql)
             for e in cur.fetchall():
                 pprint(e[0])

--- a/src/pjpersist/zope/annotation.py
+++ b/src/pjpersist/zope/annotation.py
@@ -17,10 +17,7 @@ from persistent.dict import PersistentDict
 from zope import component, interface
 from zope.annotation import interfaces
 
-try:
-    from UserDict import DictMixin
-except ImportError:
-    from collections import MutableMapping as DictMixin
+from collections import MutableMapping
 
 class IPJAttributeAnnotatable(interfaces.IAnnotatable):
     """Marker indicating that annotations can be stored on an attribute.
@@ -35,7 +32,7 @@ def normalize_key(key):
 
 @interface.implementer(interfaces.IAnnotations)
 @component.adapter(IPJAttributeAnnotatable)
-class AttributeAnnotations(DictMixin):
+class AttributeAnnotations(MutableMapping):
     """Store annotations on an object
 
     Store annotations in the `__annotations__` attribute on a

--- a/src/pjpersist/zope/annotation.py
+++ b/src/pjpersist/zope/annotation.py
@@ -67,7 +67,7 @@ class AttributeAnnotations(DictMixin):
         if annotations is None:
             return []
 
-        return annotations.keys()
+        return list(annotations.keys())
 
     def __iter__(self):
         annotations = getattr(self.obj, self.ATTR_NAME, None)

--- a/src/pjpersist/zope/tests/test_container.py
+++ b/src/pjpersist/zope/tests/test_container.py
@@ -1511,9 +1511,9 @@ class IPerson(zope.interface.Interface):
     phone = zope.schema.TextLine(title=u'Phone')
 
 
+@zope.interface.implementer(IPerson)
 class ColumnPerson(SimpleColumnSerialization, container.PJContained,
                    persistent.Persistent):
-    zope.interface.implements(IPerson)
     _p_pj_table = 'cperson'
     _pj_column_fields = select_fields(IPerson, 'name')
 
@@ -1916,9 +1916,8 @@ def setUp(test):
 
     # since the table gets created in PJContainer.__init__ we need to provide
     # a IPJDataManagerProvider
+    @zope.interface.implementer(interfaces.IPJDataManagerProvider)
     class Provider(object):
-        zope.interface.implements(interfaces.IPJDataManagerProvider)
-
         def get(self, database):
             return test.globs['dm']
 

--- a/src/pjpersist/zope/tests/test_container.py
+++ b/src/pjpersist/zope/tests/test_container.py
@@ -1907,7 +1907,7 @@ checker = renormalizing.RENormalizing([
     zope.lifecycleevent.interfaces.IObjectModifiedEvent
     )
 def handleObjectModifiedEvent(object, event):
-    print event.__class__.__name__+':', repr(object)
+    print(event.__class__.__name__+':', repr(object))
 
 
 def setUp(test):


### PR DESCRIPTION
Hi, I evaluated the PJPersist for our project and while testing it, I also decided to convert it to 2/3 polyglot - this happened mostly automatized with 2to3 doing most of the changes. I purposefully did avoid doing any 2.6 dependencies, though I noted that the existing code especially within the tests was strictly 2.7 only (used dict comprehensions etc).

Most notably, since no one in their right mind would try to use this on Python 2.5 either, for the new code it would be beneficial to use b'' and u'' consistently; along with all the Python 3 __future__s, and `except Exception as e`, etc. Also if Python 2.7 is assumed, one could use the `viewkeys`, `viewvalues` on dictionaries with `six`; these would then map directly to `keys`, `values` on Python 3

Now that SQLObject recently published a Python 3 compatible version there's not much excuse in keeping this Python 2 only ;)
