### PR TITLE
record traceback to thread local when conflict error occurs

### DIFF
--- a/src/pjpersist/testing.py
+++ b/src/pjpersist/testing.py
@@ -213,6 +213,7 @@ class PJTestCase(unittest.TestCase):
         self.dm = datamanager.PJDataManager(self.conn)
 
     def tearDown(self):
+        datamanager.CONFLICT_TRACEBACK_INFO.traceback = None
         #module.tearDown(self)
         tearDownSerializers(self)
         transaction.abort()

--- a/src/pjpersist/tests/test_datamanager.py
+++ b/src/pjpersist/tests/test_datamanager.py
@@ -1269,12 +1269,17 @@ class DatamanagerConflictTest(testing.PJTestCase):
         self.assertEqual(dm2.root['foo'].name, 'foo-first')
         del dm2.root['foo']
 
+        self.assertIsNone(
+            datamanager.CONFLICT_TRACEBACK_INFO.traceback)
+
         #Finish in order 2 - 1
 
         dm2.tpc_finish(None)
         with self.assertRaises(interfaces.ConflictError):
             dm1.tpc_finish(None)
 
+        self.assertIsNotNone(
+            datamanager.CONFLICT_TRACEBACK_INFO.traceback)
         transaction.abort()
 
         conn2.close()


### PR DESCRIPTION
This patch will help to debug ConflictErrors not getting handled properly.