### PR TITLE
capture entire stack not just up to where db exception was thrown

### DIFF
--- a/src/pjpersist/datamanager.py
+++ b/src/pjpersist/datamanager.py
@@ -230,9 +230,7 @@ def check_for_conflict(e, sql):
         psycopg2.errorcodes.DEADLOCK_DETECTED
     )
     if e.pgcode in serialization_errors:
-        t, v, b = sys.exc_info()
-        CONFLICT_TRACEBACK_INFO.traceback = traceback.format_exception(
-            t, v, b)
+        CONFLICT_TRACEBACK_INFO.traceback = traceback.format_stack()
         LOG.warning("Conflict detected with code %s sql: %s", e.pgcode, sql)
         raise interfaces.ConflictError(str(e), sql)
 

--- a/src/pjpersist/datamanager.py
+++ b/src/pjpersist/datamanager.py
@@ -350,7 +350,6 @@ class PJDataManager(object):
                                            "READ COMMITTED",
                                            "READ UNCOMMITTED"]
             modes.append("ISOLATION LEVEL %s" % self._txn_isolation)
-
         if not modes:
             return
 
@@ -364,6 +363,8 @@ class PJDataManager(object):
         cur = self._conn.cursor(cursor_factory=factory)
 
         if not self._txn_active:
+            # clear any traceback before starting next txn
+            CONFLICT_TRACEBACK_INFO.traceback = None
             self._setTransactionOptions(cur)
             self._txn_active = True
         return cur

--- a/src/pjpersist/tests/test_datamanager.py
+++ b/src/pjpersist/tests/test_datamanager.py
@@ -1414,7 +1414,7 @@ class DatamanagerConflictTest(testing.PJTestCase):
         # verify by length that we have the full traceback
         ctb = datamanager.CONFLICT_TRACEBACK_INFO.traceback
         self.assertIsNotNone(ctb)
-        self.assertEquals(len(ctb), 2)
+        self.assertEquals(len(ctb), 17)
         transaction.abort()
 
         # start another transaction and verify the traceback

--- a/src/pjpersist/tests/test_datamanager.py
+++ b/src/pjpersist/tests/test_datamanager.py
@@ -1269,17 +1269,12 @@ class DatamanagerConflictTest(testing.PJTestCase):
         self.assertEqual(dm2.root['foo'].name, 'foo-first')
         del dm2.root['foo']
 
-        self.assertIsNone(
-            datamanager.CONFLICT_TRACEBACK_INFO.traceback)
-
         #Finish in order 2 - 1
 
         dm2.tpc_finish(None)
         with self.assertRaises(interfaces.ConflictError):
             dm1.tpc_finish(None)
 
-        self.assertIsNotNone(
-            datamanager.CONFLICT_TRACEBACK_INFO.traceback)
         transaction.abort()
 
         conn2.close()
@@ -1385,6 +1380,53 @@ class DatamanagerConflictTest(testing.PJTestCase):
 
         conn2.close()
         conn1.close()
+
+    def test_conflict_tracebacks(self):
+        """Verify conflict tracebacks are captured properly
+        and reset on the next transaction."""
+
+        ctb = datamanager.CONFLICT_TRACEBACK_INFO.traceback
+        self.assertIsNone(ctb)
+
+        foo = Foo('foo-first')
+        self.dm.root['foo'] = foo
+
+        self.dm.tpc_finish(None)
+
+        conn1 = testing.getConnection(testing.DBNAME)
+        dm1 = datamanager.PJDataManager(conn1)
+        dm1.root['foo'].name = 'foo-second'
+
+        conn2 = testing.getConnection(testing.DBNAME)
+        dm2 = datamanager.PJDataManager(conn2)
+
+        del dm2.root['foo']
+
+        ctb = datamanager.CONFLICT_TRACEBACK_INFO.traceback
+        self.assertIsNone(ctb)
+
+        #Finish in order 2 - 1
+
+        dm2.tpc_finish(None)
+        with self.assertRaises(interfaces.ConflictError):
+            dm1.tpc_finish(None)
+
+        # verify by length that we have the full traceback
+        ctb = datamanager.CONFLICT_TRACEBACK_INFO.traceback
+        self.assertIsNotNone(ctb)
+        self.assertEquals(len(ctb), 2)
+        transaction.abort()
+
+        # start another transaction and verify the traceback
+        # is reset
+        datamanager.PJDataManager(conn2)
+
+        ctb = datamanager.CONFLICT_TRACEBACK_INFO.traceback
+        self.assertIsNone(ctb)
+
+        conn2.close()
+        conn1.close()
+
 
     def test_conflict_commit_1(self):
         """Test conflict on commit


### PR DESCRIPTION
current will not show the entire stack in cases where conflict
exception is thrown

format_stack seems to do the right thing and should be sufficient
since we don't care about traceback_info