### PR TITLE
Introduce _pj_get_resolve_filter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(*rnames):
 
 setup(
     name='pjpersist',
-    version='0.8.12',
+    version='0.8.13',
     author="Shoobx Team",
     author_email="dev@shoobx.com",
     url='https://github.com/Shoobx/pjpersist',

--- a/src/pjpersist/zope/interfaces.py
+++ b/src/pjpersist/zope/interfaces.py
@@ -51,15 +51,13 @@ class IPJContainer(zope.interface.Interface):
         the parent of the item.
         """
 
-    def _pj_get_items_filter():
+    def _pj_get_resolve_filter():
+        """Returns a query to filter to apply when querying for single id
+        """
+
+    def _pj_get_list_filter():
         """Returns a query spec representing a filter that only returns
         objects in this container."""
-
-    def _pj_add_items_filter(filter):
-        """Applies the item filter items to the provided filter.
-
-        Keys that are already in the passed in filter are not overwritten.
-        """
 
     def convert_mongo_query(spec):
         """BBB: providing support for mongo style queries"""


### PR DESCRIPTION
This will allow to specify less strict filter for items, resolved by id
versus ones, found by query. This is useful when we want to omit some
(i.e. "deleted") items from being returned by queries, but still want to
access them if we know their id.

Also, rename _pj_get_items_filter to _pj_get_list_filter.