### PR TITLE
restore dict tuple keys as tuples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ CHANGES
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed persisting tuple keyed dicts. Persisting such objects worked,
+  but reading failed.
 
 
 2.0.0 (2020-06-02)
@@ -17,9 +18,9 @@ CHANGES
 - Remove buildout support.
 
 - Support for nested flushing. In complex use cases it can happen that during
-  serialization of an object, a query is made to look up another obejct. Taht
+  serialization of an object, a query is made to look up another object. That
   in turn causes a flush, resulting in a flush inside a flush. The `flush()`
-  method did not expect that behavior and fialed if the inner flush would
+  method did not expect that behavior and failed if the inner flush would
   flush objects that the outer flush had already handled.
 
 

--- a/src/pjpersist/tests/test_serialize.py
+++ b/src/pjpersist/tests/test_serialize.py
@@ -424,6 +424,19 @@ def doctest_ObjectWriter_get_state_mappings():
       >>> pprint.pprint(sorted(state['dict_data']))
       [('1', 1), ('dict_data', 'works?')]
 
+    It gets even worse with tuple keyed mappings,
+    tuple keys get converted to JSON as a list,
+    which need to be handled then by get_object
+
+      >>> mapping = {
+      ...     (1, 'key-one', None): 'value-one',
+      ...     (2, 'key-two', True): 'value-two',
+      ...     'key-three': 'value-three'}
+      >>> pprint.pprint(writer.get_state(mapping))
+      {'dict_data': [([1, 'key-one', None], 'value-one'),
+                     ([2, 'key-two', True], 'value-two'),
+                     ('key-three', 'value-three')]}
+
     """
 
 def doctest_ObjectWriter_get_state_Persistent():
@@ -1100,6 +1113,19 @@ def doctest_ObjectReader_get_object_mapping():
       ...     {'dict_data': [(1, '1'), (2, '2'), (3, '3')]},
       ...     None)))
       {1: '1', 2: '2', 3: '3'}
+
+    It gets even worse with tuple keyed mappings,
+    tuple keys get converted to JSON as a list,
+    which need to be handled then by get_object
+
+      >>> inp = {'dict_data': [([1, 'key-one', None], 'value-one'),
+      ...                      ([2, 'key-two', True], 'value-two'),
+      ...                      ('key-three', 'value-three')]}
+      >>> pprint.pprint(dict(reader.get_object(inp, None)))
+      {'key-three': 'value-three',
+       (1, 'key-one', None): 'value-one',
+       (2, 'key-two', True): 'value-two'}
+
     """
 
 def doctest_ObjectReader_get_object_constant():


### PR DESCRIPTION
the problem was:

Given a mapping like 
```
      >>> mapping = {
      ...     (1, 'key-one', None): 'value-one',
      ...     (2, 'key-two', True): 'value-two',
      ...     'key-three': 'value-three'}
```
got persisted as
```
      {'dict_data': [([1, 'key-one', None], 'value-one'),
                     ([2, 'key-two', True], 'value-two'),
                     ('key-three', 'value-three')]}
```
Notice the keys got converted to list, because JSON does not support tuples.
Sofar so good.

But converting back to an object failed in `get_object` because dicts cannot have unhashable keys (list).

This fix is converting list keys of a dict to tuple when needed.