### PR TITLE
Add handling of failed postgres transactions when two-phase-commit is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@ CHANGES
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add handling of failed postgres transactions when two-phase-commit
+  is enabled.  A corner case, when someone re-uses a connection used
+  by PJDataManager, executes bad SQL leaving the postgres transaction
+  in failed state, and finally tries to commit or abort the python
+  transaction.
 
 
 2.0.1 (2020-10-13)


### PR DESCRIPTION

- begin a python transaction, make PJDataManager join it
- re-use postgres connection from PJDataManager to execute some bad raw SQL, breaking the postgres transaction
- finally, try to commit or abort the python transaction

Postgres PREPARE TRANSACTION statement does not create a prepared transaction, but `psycopg2` is not aware of that, and sets connection status to STATUS_PREPARED.  When we eventually try to `tpc_vote` or `tpc_abort`, the transaction cannot be found and UndefinedObject exception is raised.

The problem is, that PJDataManager then leaves the connection in broken state, so it can never be used for another transaction.

This PR resets the connection and leaves it at STATUS_READY if the prepared transaction is missing.  If the prepared transaction is gone, there's nothing to commit or roll back on the database side.