### PR TITLE
Switch PJDataManager to use connection pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ tmp
 htmlcov
 coverage
 coverage.xml
+dist
 .tox/
 .venv/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,17 @@ CHANGES
 =======
 
 
-2.0.2 (unreleased)
+3.0.0 (unreleased)
 ------------------
+
+- Backwards incompatible change: PJDataManager now accepts a pool instead
+  of connection object. PJDataManager will get the connection from the pool
+  when joining the transaction, and return it back when transaction
+  completes (aborts or commits). This allows for more flexible connection
+  management. The connection pool must implement IPJConnectionPool interface
+  (it is compatible with psycopg2.pool).
+
+- `IPJDataManager.begin()` is renamed to `setTransactionOptions()`
 
 - Errors executing SQL statements now doom the entire transaction,
   causing `transaction.interfaces.DoomedTransaction` exception on

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ TESTS_REQUIRE = [
 
 setup(
     name='pjpersist',
-    version='2.0.2.dev0',
+    version='2.0.2.dev6',
     author="Shoobx Team",
     author_email="dev@shoobx.com",
     url='https://github.com/Shoobx/pjpersist',

--- a/src/pjpersist/interfaces.py
+++ b/src/pjpersist/interfaces.py
@@ -46,6 +46,10 @@ class DatabaseDisconnected(transaction.interfaces.TransientError):
     pass
 
 
+class ReadOnlyDataManagerError(transaction.interfaces.TransactionError):
+    """Attempt to modify objects governed by a read-only data manager."""
+
+
 class IObjectSerializer(zope.interface.Interface):
     """An object serializer allows for custom serialization output for
     objects."""
@@ -114,6 +118,20 @@ class IObjectReader(zope.interface.Interface):
         """
 
 
+class IPJConnectionPool(zope.interface.Interface):
+    def getconn():
+        """Get connection from the pool"""
+
+    def putconn(conn):
+        """Put conncetion back to the pool"""
+
+    def closeall():
+        """Close all connection in the pool"""
+
+    def reopen():
+        """Reopen the pool after it was closed"""
+
+
 class IPJDataManager(persistent.interfaces.IPersistentDataManager):
     """A persistent data manager that stores data in PostGreSQL/JSONB."""
 
@@ -168,6 +186,15 @@ class IPJDataManager(persistent.interfaces.IPersistentDataManager):
 
     def setDirty():
         """Set dirty flag"""
+
+    def setTransactionOptions(
+        readonly: bool = None,
+        deferrable: bool = None,
+        isolation_level: int = None) -> None:
+        """Set the options for the future transaction
+
+        Options can only be set before the postgres transaction has started
+        """
 
 
 class IPJDataManagerProvider(zope.interface.Interface):

--- a/src/pjpersist/zope/tests/test_container.py
+++ b/src/pjpersist/zope/tests/test_container.py
@@ -632,7 +632,6 @@ def doctest_PJContainer_concurrent_adds():
 
       >>> dm.root['people'] = container.IdNamesPJContainer('person')
       >>> dm.root['people'].add(Person('Roy'))
-      >>> dm.commit(None)
       >>> commit()
 
     Let's register a query stats listener:
@@ -655,7 +654,7 @@ def doctest_PJContainer_concurrent_adds():
       ...     def add_person():
       ...         conn2 = testing.getConnection(testing.DBNAME)
       ...         try:
-      ...             dm2 = datamanager.PJDataManager(conn2)
+      ...             dm2 = datamanager.PJDataManager(testing.DummyConnectionPool(conn2))
       ...             ppl = dm2.root['people']
       ...
       ...             ppl.add(Person('Stephan %s' % i))
@@ -1906,12 +1905,12 @@ class ContainerConflictTest(testing.PJTestCase):
         transaction.commit()
 
         conn2 = testing.getConnection(testing.DBNAME)
-        dm2 = datamanager.PJDataManager(conn2)
+        dm2 = datamanager.PJDataManager(testing.DummyConnectionPool(conn2))
 
         dm2.root['c']['stephan'] = SimplePerson('Stephan')
 
         conn1 = testing.getConnection(testing.DBNAME)
-        dm1 = datamanager.PJDataManager(conn1)
+        dm1 = datamanager.PJDataManager(testing.DummyConnectionPool(conn1))
 
         dm1.root['c']['stephan'] = SimplePerson('Stephan')
 
@@ -1933,12 +1932,12 @@ class ContainerConflictTest(testing.PJTestCase):
         transaction.commit()
 
         conn1 = testing.getConnection(testing.DBNAME)
-        dm1 = datamanager.PJDataManager(conn1)
+        dm1 = datamanager.PJDataManager(testing.DummyConnectionPool(conn1))
 
         dm1.root['c']['stephan'] = SimplePerson('Stephan')
 
         conn2 = testing.getConnection(testing.DBNAME)
-        dm2 = datamanager.PJDataManager(conn2)
+        dm2 = datamanager.PJDataManager(testing.DummyConnectionPool(conn2))
 
         dm2.root['c']['stephan'] = SimplePerson('Stephan')
 
@@ -1961,12 +1960,12 @@ class ContainerConflictTest(testing.PJTestCase):
         transaction.commit()
 
         conn2 = testing.getConnection(testing.DBNAME)
-        dm2 = datamanager.PJDataManager(conn2)
+        dm2 = datamanager.PJDataManager(testing.DummyConnectionPool(conn2))
 
         dm2.root['c']['stephan'] = Person('Stephan')
 
         conn1 = testing.getConnection(testing.DBNAME)
-        dm1 = datamanager.PJDataManager(conn1)
+        dm1 = datamanager.PJDataManager(testing.DummyConnectionPool(conn1))
 
         dm1.root['c']['stephan'] = Person('Stephan')
 
@@ -1989,12 +1988,12 @@ class ContainerConflictTest(testing.PJTestCase):
         transaction.commit()
 
         conn1 = testing.getConnection(testing.DBNAME)
-        dm1 = datamanager.PJDataManager(conn1)
+        dm1 = datamanager.PJDataManager(testing.DummyConnectionPool(conn1))
 
         dm1.root['c']['stephan'] = Person('Stephan')
 
         conn2 = testing.getConnection(testing.DBNAME)
-        dm2 = datamanager.PJDataManager(conn2)
+        dm2 = datamanager.PJDataManager(testing.DummyConnectionPool(conn2))
 
         dm2.root['c']['stephan'] = Person('Stephan')
 
@@ -2017,10 +2016,10 @@ class ContainerConflictTest(testing.PJTestCase):
         transaction.commit()
 
         conn1 = testing.getConnection(testing.DBNAME)
-        dm1 = datamanager.PJDataManager(conn1)
+        dm1 = datamanager.PJDataManager(testing.DummyConnectionPool(conn1))
         dm1.createId = lambda: 'abcd'
         conn2 = testing.getConnection(testing.DBNAME)
-        dm2 = datamanager.PJDataManager(conn2)
+        dm2 = datamanager.PJDataManager(testing.DummyConnectionPool(conn2))
         dm2.createId = lambda: 'abcd'
 
         dm1.root['c']['stephan1'] = Person('Stephan1')


### PR DESCRIPTION
Backwards incompatible change: `PJDataManager` will work with a connection pool instead of connection directly.

When joining the transaction, `PJDataManager` will get the connection from the pool. When transaction commits or aborts, the connection will be returned to the pool.

This allows for more flexible connection management. The pool can control
when to reuse or when to close the database connection.