### PR TITLE
Fix `DBRef` comparisons (`__eq__` and `__neq__`)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,10 @@ CHANGES
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix `DBRef` comparisons to return valid results instead
+  of failing hard  when comparing to `None` and not `DBRef` instances.
+  (`__neq__` was unused because `__ne__` is the right method and `__ne__` anyway
+  delegates to `__eq__`)
 
 3.0.1 (2022-02-03)
 ------------------

--- a/src/pjpersist/serialize.py
+++ b/src/pjpersist/serialize.py
@@ -192,10 +192,11 @@ class DBRef(object):
         return self.hash
 
     def __eq__(self, other):
-        return self.hash == other.hash
-
-    def __neq__(self, other):
-        return self.hash != other.hash
+        try:
+            return self.hash == other.hash
+        except AttributeError:
+            # `other` is not a DBRef or is None
+            return False
 
     def __repr__(self):
         return 'DBRef(%r, %r, %r)' %(self.table, self.id, self.database)

--- a/src/pjpersist/tests/test_serialize.py
+++ b/src/pjpersist/tests/test_serialize.py
@@ -182,6 +182,21 @@ def doctest_DBRef():
       True
       >>> id(dbref1) == id(dbref11)
       False
+
+    Don't fail on various comparisons:
+
+      >>> dbref1 == None
+      False
+
+      >>> dbref1 == Simple
+      False
+
+      >>> dbref1 != None
+      True
+
+      >>> dbref1 != Simple
+      True
+
     """
 
 def doctest_ObjectSerializer():


### PR DESCRIPTION
Fix `DBRef` comparisons (`__eq__` and `__neq__`) to return valid results instead of failing hard  when comparing to `None` and not `DBRef` instances.