### PR TITLE
Fast flush

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ CHANGES
 3.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Faster PJDataManager flush() when it contains a lot of objects.
 
 
 3.1.2 (2022-07-15)


### PR DESCRIPTION
This increases performance of `PJDataManager.flush()` significantly when data manager contains large amount of changed objects.

Consider the situations when `PJDataManager` instance has thousands of objects registered to be stored in table `A` and one object to be stored in table `B`. When the data manager is asked to `flush(flush_hint=["B"])`, the previous implementation has to go through each of `A` objects, compute the destination table and then compute `todo = set(self._registered_objects.keys()) - processed` with ever-increasing `processed` set. This becomes very expensive computations with numbers of items in orders of magnitude of tens thousands and more.

This change makes the `flush()` performance only depend on number of objects it needs to flush.

PR contains 2 commits: one is the refactoring of old `flush()` implementation to make it more readable and manageable. The second is the actual performance optimization.