### PR TITLE
Fix short year edgecase

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ CHANGES
 
 - Moving CI to github actions.
 - Declare Python 3.11 compatibility
+- Fix serialization for dates where year is shorter than 4 digits long
+- Fix type checking in `serializers.py`
 
 3.1.3 (2022-11-23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ CHANGES
 - Moving CI to github actions.
 - Declare Python 3.11 compatibility
 - Fix serialization for dates where year is shorter than 4 digits long
-- Fix type checking in `serializers.py`
+
 
 3.1.3 (2022-11-23)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -217,7 +217,7 @@ Of course all properties can be retrieved as python objects:
   <Phone +1-978-394-5124>
 
   >>> stephan.today
-  datetime.datetime(2011, 10, 1, 9, 45)
+  datetime.datetime(2014, 12, 4, 12, 30)
 
   >>> stephan.visited
   [u'Germany', u'USA']

--- a/src/pjpersist/serialize.py
+++ b/src/pjpersist/serialize.py
@@ -347,13 +347,13 @@ class ObjectWriter(object):
 
         if objectType == datetime.date:
             return {'_py_type': 'datetime.date',
-                    'value': obj.strftime(FMT_DATE)}
+                    'value': obj.strftime(FMT_DATE).zfill(10)}
         if objectType == datetime.time:
             return {'_py_type': 'datetime.time',
                     'value': obj.strftime(FMT_TIME)}
         if objectType == datetime.datetime:
             return {'_py_type': 'datetime.datetime',
-                    'value': obj.strftime(FMT_DATETIME)}
+                    'value': obj.strftime(FMT_DATETIME).zfill(26)}
 
         # Let's handle only specific MappingView subclasses for now
         if objectType in COLLECTIONS_ABC_MAPPINGVIEWS:

--- a/src/pjpersist/serialize.py
+++ b/src/pjpersist/serialize.py
@@ -41,6 +41,8 @@ TABLE_KLASS_MAP = {}
 FMT_DATE = "%Y-%m-%d"
 FMT_TIME = "%H:%M:%S.%f"
 FMT_DATETIME = "%Y-%m-%dT%H:%M:%S.%f"
+FMT_DATE_LENGTH = 10
+FMT_DATETIME_LENGTH = 26
 
 # BBB: Will be removed in 2.0.
 FMT_TIME_BBB = "%H:%M:%S"
@@ -347,13 +349,13 @@ class ObjectWriter(object):
 
         if objectType == datetime.date:
             return {'_py_type': 'datetime.date',
-                    'value': obj.strftime(FMT_DATE).zfill(10)}
+                    'value': obj.strftime(FMT_DATE).zfill(FMT_DATE_LENGTH)}
         if objectType == datetime.time:
             return {'_py_type': 'datetime.time',
                     'value': obj.strftime(FMT_TIME)}
         if objectType == datetime.datetime:
             return {'_py_type': 'datetime.datetime',
-                    'value': obj.strftime(FMT_DATETIME).zfill(26)}
+                    'value': obj.strftime(FMT_DATETIME).zfill(FMT_DATETIME_LENGTH)}
 
         # Let's handle only specific MappingView subclasses for now
         if objectType in COLLECTIONS_ABC_MAPPINGVIEWS:

--- a/src/pjpersist/serializers.py
+++ b/src/pjpersist/serializers.py
@@ -19,6 +19,7 @@ from pjpersist import serialize
 class DateSerializer(serialize.ObjectSerializer):
 
     fmt = "%Y-%m-%d"
+    fmtLength = 10
 
     def can_read(self, state):
         return isinstance(state, dict) and \
@@ -28,11 +29,11 @@ class DateSerializer(serialize.ObjectSerializer):
         return datetime.datetime.strptime(state['value'], self.fmt).date()
 
     def can_write(self, obj):
-        return type(obj) is datetime.date
+        return isinstance(obj, datetime.date)
 
     def write(self, obj):
         return {'_py_type': 'datetime.date',
-                'value': obj.strftime(self.fmt).zfill(10)}
+                'value': obj.strftime(self.fmt).zfill(self.fmtLength)}
 
 
 class TimeSerializer(serialize.ObjectSerializer):
@@ -47,7 +48,7 @@ class TimeSerializer(serialize.ObjectSerializer):
         return datetime.datetime.strptime(state['value'], self.fmt).time()
 
     def can_write(self, obj):
-        return type(obj) is datetime.time
+        return isinstance(obj, datetime.time)
 
     def write(self, obj):
         return {'_py_type': 'datetime.time',
@@ -57,7 +58,8 @@ class TimeSerializer(serialize.ObjectSerializer):
 class DateTimeSerializer(serialize.ObjectSerializer):
 
     # XXX: timezone?
-    fmt = "%Y-%m-%dT%H:%M:%S.%f"
+    fmt = "%Y-%m-%dT%H:%M:%S"
+    fmtLength = 19
 
     def can_read(self, state):
         return isinstance(state, dict) and \
@@ -67,8 +69,8 @@ class DateTimeSerializer(serialize.ObjectSerializer):
         return datetime.datetime.strptime(state['value'], self.fmt)
 
     def can_write(self, obj):
-        return type(obj) is datetime.datetime
+        return isinstance(obj, datetime.datetime)
 
     def write(self, obj):
         return {'_py_type': 'datetime.datetime',
-                'value': obj.strftime(self.fmt).zfill(26)}
+                'value': obj.strftime(self.fmt).zfill(self.fmtLength)}

--- a/src/pjpersist/serializers.py
+++ b/src/pjpersist/serializers.py
@@ -28,11 +28,11 @@ class DateSerializer(serialize.ObjectSerializer):
         return datetime.datetime.strptime(state['value'], self.fmt).date()
 
     def can_write(self, obj):
-        return isinstance(obj, datetime.date)
+        return type(obj) is datetime.date
 
     def write(self, obj):
         return {'_py_type': 'datetime.date',
-                'value': obj.strftime(self.fmt)}
+                'value': obj.strftime(self.fmt).zfill(10)}
 
 
 class TimeSerializer(serialize.ObjectSerializer):
@@ -47,7 +47,7 @@ class TimeSerializer(serialize.ObjectSerializer):
         return datetime.datetime.strptime(state['value'], self.fmt).time()
 
     def can_write(self, obj):
-        return isinstance(obj, datetime.time)
+        return type(obj) is datetime.time
 
     def write(self, obj):
         return {'_py_type': 'datetime.time',
@@ -57,7 +57,7 @@ class TimeSerializer(serialize.ObjectSerializer):
 class DateTimeSerializer(serialize.ObjectSerializer):
 
     # XXX: timezone?
-    fmt = "%Y-%m-%dT%H:%M:%S"
+    fmt = "%Y-%m-%dT%H:%M:%S.%f"
 
     def can_read(self, state):
         return isinstance(state, dict) and \
@@ -67,8 +67,8 @@ class DateTimeSerializer(serialize.ObjectSerializer):
         return datetime.datetime.strptime(state['value'], self.fmt)
 
     def can_write(self, obj):
-        return isinstance(obj, datetime.datetime)
+        return type(obj) is datetime.datetime
 
     def write(self, obj):
         return {'_py_type': 'datetime.datetime',
-                'value': obj.strftime(self.fmt)}
+                'value': obj.strftime(self.fmt).zfill(26)}

--- a/src/pjpersist/testing.py
+++ b/src/pjpersist/testing.py
@@ -43,9 +43,6 @@ py3checkers = [
 ]
 
 checker = renormalizing.RENormalizing([
-    # Date/Time objects
-    (re.compile(r'datetime.datetime\(.*\)'),
-     'datetime.datetime(2011, 10, 1, 9, 45)'),
     # IDs
     (re.compile(r"'[0-9a-f]{24}'"), "'0001020304050607080a0b0c0'"),
     ] + py3checkers)

--- a/src/pjpersist/tests/test_serialize.py
+++ b/src/pjpersist/tests/test_serialize.py
@@ -1496,7 +1496,7 @@ def doctest_ObjectWriter_date_short_year():
 
     Also check custom serializers
       >>> from pjpersist.serializers import DateSerializer, DateTimeSerializer
-      >>> serialize.SERIALIZERS = [DateSerializer(), DateTimeSerializer()]
+      >>> serialize.SERIALIZERS = [DateTimeSerializer(), DateSerializer()]
 
     Check date
       >>> import datetime
@@ -1512,7 +1512,7 @@ def doctest_ObjectWriter_date_short_year():
       >>> state = writer.get_state(datetime.datetime(23, 12, 1, 13, 33, 56, 622000))
       >>> reader = serialize.ObjectReader(dm)
       >>> reader.get_object(state, None)
-      datetime.datetime(23, 12, 1, 13, 33, 56, 622000)
+      datetime.datetime(23, 12, 1, 13, 33, 56)
     """
 
 

--- a/src/pjpersist/tests/test_serialize.py
+++ b/src/pjpersist/tests/test_serialize.py
@@ -1070,7 +1070,7 @@ def doctest_ObjectReader_get_object_datetime():
       ...         'value': '2005-07-13T17:18:10.100000',
       ...     },
       ...     None)
-      datetime.datetime(2005, 07, 13, 17, 18, 10, 100000)
+      datetime.datetime(2005, 7, 13, 17, 18, 10, 100000)
     """
 
 def doctest_ObjectReader_get_object_datetime_BBB():
@@ -1469,6 +1469,50 @@ def doctest_table_decorator():
       ...
       TypeError: ("Can't declare _p_pj_table", <object object at ...>)
 
+    """
+
+def doctest_ObjectWriter_date_short_year():
+    """
+    Check if serialization works with a shorter year than 4 digits
+
+    Clear custom serializers
+      >>> serialize.SERIALIZERS = []
+
+    Check date
+      >>> import datetime
+      >>> writer = serialize.ObjectWriter(dm)
+      >>> state = writer.get_state(datetime.date(111, 2, 3))
+      >>> reader = serialize.ObjectReader(dm)
+      >>> reader.get_object(state, None)
+      datetime.date(111, 2, 3)
+
+    Check datetime
+      >>> import datetime 
+      >>> writer = serialize.ObjectWriter(dm)
+      >>> state = writer.get_state(datetime.datetime(342, 11, 7, 16, 57, 34, 780005))
+      >>> reader = serialize.ObjectReader(dm)
+      >>> reader.get_object(state, None)
+      datetime.datetime(342, 11, 7, 16, 57, 34, 780005)
+
+    Also check custom serializers
+      >>> from pjpersist.serializers import DateSerializer, DateTimeSerializer
+      >>> serialize.SERIALIZERS = [DateSerializer(), DateTimeSerializer()]
+
+    Check date
+      >>> import datetime
+      >>> writer = serialize.ObjectWriter(dm)
+      >>> state = writer.get_state(datetime.date(5, 12, 4))
+      >>> reader = serialize.ObjectReader(dm)
+      >>> reader.get_object(state, None)
+      datetime.date(5, 12, 4)
+
+    Check datetime
+      >>> import datetime 
+      >>> writer = serialize.ObjectWriter(dm)
+      >>> state = writer.get_state(datetime.datetime(23, 12, 1, 13, 33, 56, 622000))
+      >>> reader = serialize.ObjectReader(dm)
+      >>> reader.get_object(state, None)
+      datetime.datetime(23, 12, 1, 13, 33, 56, 622000)
     """
 
 


### PR DESCRIPTION
- Fix serialization for dates where year is shorter than 4 digits long.
When a date or datetime was passed it would be saved and then at read time it would throw an error.
For example saving `datetime.date(123, 11, 7)` would result in `123-11-07` which would be not readable because the year doesn't match the format of four digit year.
- Remove normalizing of `datetime.datetime` from checker in `testing.py`
- Fix type checks in `serializers.py`